### PR TITLE
Bootstrap CRUD operations for Projects and Characters (and Takes)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,12 @@ jobs:
           - 3.1
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Run the default task
-      run: bundle exec rake
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          # FIXME: Rubocop fails when using `bundler-cache: true`
+          # bundler-cache: true
+
+      - run: bundle install
+      - run: bundle exec rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,12 +11,30 @@ AllCops:
   Exclude:
     - bin/**/*
 
+# ------------------------------------------------------------------------------
+# DEPARTMENT LAYOUT
+# ------------------------------------------------------------------------------
+
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent # default: special_inside_parentheses
+
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent # default: special_inside_parentheses
+
 Layout/LineLength:
   Max: 100 # default: 120
+
+# ------------------------------------------------------------------------------
+# DEPARTMENT METRICS
+# ------------------------------------------------------------------------------
 
 Metrics/BlockLength:
   Exclude:
   - spec/**/*
+
+# ------------------------------------------------------------------------------
+# DEPARTMENT STYLE
+# ------------------------------------------------------------------------------
 
 Style/Documentation:
   Enabled: false # default: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,5 +14,9 @@ AllCops:
 Layout/LineLength:
   Max: 100 # default: 120
 
+Metrics/BlockLength:
+  Exclude:
+  - spec/**/*
+
 Style/Documentation:
   Enabled: false # default: true

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
+  gem 'debug', '~> 1.4'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.21', require: false
   gem 'rubocop-performance', '~> 1.13', require: false
@@ -14,6 +15,6 @@ group :development do
 end
 
 group :test do
-  gem 'simplecov', require: false
   gem 'rspec', '~> 3.0'
+  gem 'simplecov', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,19 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'debug', '~> 1.4'
   gem 'rake', '~> 13.0'
   gem 'rubocop', '~> 1.21', require: false
   gem 'rubocop-performance', '~> 1.13', require: false
   gem 'rubocop-rake', '~> 0.6.0', require: false
   gem 'rubocop-rspec', '~> 2.7', require: false
+  gem 'yard', '~> 0.9.27', require: false
 end
 
 group :test do
   gem 'rspec', '~> 3.0'
   gem 'simplecov', require: false
+end
+
+group :development, :test do
+  gem 'debug', '~> 1.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,9 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     unicode-display_width (2.1.0)
+    webrick (1.7.0)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
 
 PLATFORMS
   x86_64-linux
@@ -83,6 +86,7 @@ DEPENDENCIES
   rubocop-rake (~> 0.6.0)
   rubocop-rspec (~> 2.7)
   simplecov
+  yard (~> 0.9.27)
 
 BUNDLED WITH
    2.2.32

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,18 +8,26 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    debug (1.4.0)
+      irb (>= 1.3.6)
+      reline (>= 0.2.7)
     diff-lcs (1.5.0)
     docile (1.4.0)
     faraday (2.0.1)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.1)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.2.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -66,6 +74,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  debug (~> 1.4)
   enginn!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ Or install it yourself as:
 client = Enginn::Client.new(api_token: 'xxxxx')
 
 # Retrieve a project
-project = client.projects('xxxxx')
+project = client.projects.where(id: 'xxxxx').first
 
 # Manipulate collections
-characters = project.characters(gender_eq: 'male') # fitlers
+characters = project.characters.where(gender_eq: 'male')
 characters.each do |character|
     # ...
 end
 
 # Update a character
-character = project.characters('xxxxx').fetch!
+character = project.characters.first
 character.name = 'Pilou'
 character.save!
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Enginn
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/enginn`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+The official gem to interact with the [Enginn API](https://app.enginn.tech/api/docs/index.html).
 
 ## Installation
 
@@ -22,7 +20,20 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+```rb
+client = Enginn::Client.new(api_token: 'xxxxx')
+project = client.projects('xxxxx')
+
+characters = project.characters(gender_eq: 'male')
+characters = project.characters.filters(gender_eq: 'female').page(2)
+characters.each do |character|
+    # ...
+end
+
+character = project.characters('xxxxx').fetch!
+character.name = 'Pilou'
+character.save!
+```
 
 ## Development
 
@@ -32,7 +43,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/enginn.
+Bug reports and pull requests are welcome on GitHub at https://github.com/EnginnTechnologies/enginn-rb.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ character.name = 'Pilou'
 character.save!
 
 # Create a new character
-character = Enginn::Character.new(client, project, name: 'Raph', gender: 'male', ...)
+character = Enginn::Character.new(project, name: 'Raph', gender: 'male', ...)
 character.save!
 
 # Destroy a character

--- a/README.md
+++ b/README.md
@@ -21,18 +21,29 @@ Or install it yourself as:
 ## Usage
 
 ```rb
+# Create a client
 client = Enginn::Client.new(api_token: 'xxxxx')
+
+# Retrieve a project
 project = client.projects('xxxxx')
 
-characters = project.characters(gender_eq: 'male')
-characters = project.characters.filters(gender_eq: 'female').page(2)
+# Manipulate collections
+characters = project.characters(gender_eq: 'male') # fitlers
 characters.each do |character|
     # ...
 end
 
+# Update a character
 character = project.characters('xxxxx').fetch!
 character.name = 'Pilou'
 character.save!
+
+# Create a new character
+character = Enginn::Character.new(client, project, name: 'Raph', gender: 'male', ...)
+character.save!
+
+# Destroy a character
+character.destroy!
 ```
 
 ## Development

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+Bundler.require(:development)
 require 'enginn'
 require 'irb'
 

--- a/bin/console
+++ b/bin/console
@@ -5,12 +5,7 @@ require 'bundler/setup'
 require 'enginn'
 require 'irb'
 
-module Enginn
-  class Client
-    BASE_URL = ENV['ENGINN_BASE_URL'] || BASE_URL
-  end
-end
-
-client = Enginn::Client.new(api_token: ENV['ENGINN_API_TOKEN'])
+Enginn::Client::BASE_URL = ENV['ENGINN_BASE_URL'] unless ENV['ENGINN_BASE_URL'].nil?
+@client = Enginn::Client.new(api_token: ENV['ENGINN_API_TOKEN'])
 
 IRB.start(__FILE__)

--- a/bin/console
+++ b/bin/console
@@ -5,9 +5,9 @@ require 'bundler/setup'
 require 'enginn'
 require 'irb'
 
-Enginn::Client::BASE_URL = ENV['ENGINN_BASE_URL'] unless ENV['ENGINN_BASE_URL'].nil?
 @client = Enginn::Client.new(api_token: ENV['ENGINN_API_TOKEN'])
 @client.connection do |conn|
+  conn.url_prefix = ENV['ENGINN_BASE_URL'] || Enginn::Client::BASE_URL
   conn.response :logger
 end
 

--- a/bin/console
+++ b/bin/console
@@ -7,5 +7,8 @@ require 'irb'
 
 Enginn::Client::BASE_URL = ENV['ENGINN_BASE_URL'] unless ENV['ENGINN_BASE_URL'].nil?
 @client = Enginn::Client.new(api_token: ENV['ENGINN_API_TOKEN'])
+@client.connection do |conn|
+  conn.response :logger
+end
 
 IRB.start(__FILE__)

--- a/lib/enginn.rb
+++ b/lib/enginn.rb
@@ -3,6 +3,14 @@
 require_relative 'enginn/version'
 require_relative 'enginn/client'
 
+require_relative 'enginn/resource'
+require_relative 'enginn/project'
+require_relative 'enginn/character'
+
+require_relative 'enginn/resource_index'
+require_relative 'enginn/projects_index'
+require_relative 'enginn/characters_index'
+
 module Enginn
   class Error < StandardError; end
 end

--- a/lib/enginn.rb
+++ b/lib/enginn.rb
@@ -4,12 +4,14 @@ require_relative 'enginn/version'
 require_relative 'enginn/client'
 
 require_relative 'enginn/resource'
-require_relative 'enginn/project'
 require_relative 'enginn/character'
+require_relative 'enginn/take'
+require_relative 'enginn/project'
 
 require_relative 'enginn/resource_index'
-require_relative 'enginn/projects_index'
 require_relative 'enginn/characters_index'
+require_relative 'enginn/takes_index'
+require_relative 'enginn/projects_index'
 
 module Enginn
   class Error < StandardError; end

--- a/lib/enginn.rb
+++ b/lib/enginn.rb
@@ -2,6 +2,7 @@
 
 require_relative 'enginn/version'
 require_relative 'enginn/client'
+require_relative 'enginn/error'
 
 require_relative 'enginn/resource'
 require_relative 'enginn/character'
@@ -14,5 +15,4 @@ require_relative 'enginn/takes_index'
 require_relative 'enginn/projects_index'
 
 module Enginn
-  class Error < StandardError; end
 end

--- a/lib/enginn/character.rb
+++ b/lib/enginn/character.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Enginn
+  class Character < Resource
+    def self.path
+      'characters'
+    end
+  end
+end

--- a/lib/enginn/character.rb
+++ b/lib/enginn/character.rb
@@ -6,25 +6,10 @@ module Enginn
       'characters'
     end
 
-    # Retrieve one or multiple takes(s) of this character.
-    #
-    # If no discriminant is given, return a {Enginn::TakesIndex} with no
-    # filters. If a Hash is given, return a {Enginn::TakesIndex} filtered
-    # with the given Hash.
-    # If a String is given, return a {Enginn::Take} with its ID set as the
-    # given String.
-    #
-    # @param discriminant [nil, String, Hash]
-    # @return [Enginn::Take, Enginn::TakesIndex]
-    def takes(arg = nil)
-      case arg
-      when String
-        Take.new(@project, { id: arg }.merge(character_id_eq: @attributes[:id]))
-      when Hash
-        TakesIndex.new(@project).where(arg.merge(character_id_eq: @attributes[:id]))
-      else
-        TakesIndex.new(@project).where(character_id_eq: @attributes[:id])
-      end
+    # Retrieve the takes of this character.
+    # @return [Enginn::TakesIndex]
+    def takes
+      TakesIndex.new(@project).where(character_id_eq: @attributes[:id])
     end
   end
 end

--- a/lib/enginn/character.rb
+++ b/lib/enginn/character.rb
@@ -5,5 +5,26 @@ module Enginn
     def self.path
       'characters'
     end
+
+    # Retrieve one or multiple takes(s) of this character.
+    #
+    # If no discriminant is given, return a {Enginn::TakesIndex} with no
+    # filters. If a Hash is given, return a {Enginn::TakesIndex} filtered
+    # with the given Hash.
+    # If a String is given, return a {Enginn::Take} with its ID set as the
+    # given String.
+    #
+    # @param discriminant [nil, String, Hash]
+    # @return [Enginn::Take, Enginn::TakesIndex]
+    def takes(arg = nil)
+      case arg
+      when String
+        Take.new(@project, { id: arg }.merge(character_id_eq: @attributes[:id]))
+      when Hash
+        TakesIndex.new(@project).where(arg.merge(character_id_eq: @attributes[:id]))
+      else
+        TakesIndex.new(@project).where(character_id_eq: @attributes[:id])
+      end
+    end
   end
 end

--- a/lib/enginn/characters_index.rb
+++ b/lib/enginn/characters_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Enginn
+  class CharactersIndex < ResourceIndex
+    def self.resource
+      Character
+    end
+  end
+end

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -27,8 +27,21 @@ module Enginn
         conn.request :authorization, 'Bearer', -> { @api_token }
         conn.request :json
         conn.response :json
+        conn.response :logger
+        conn.response :raise_error
       end
       block_given? ? yield(@connection) : @connection
+    end
+
+    def projects(arg = nil)
+      case arg
+      when String
+        Project.new(self, { uid: arg })
+      when Hash
+        ProjectsIndex.new(self, arg)
+      else
+        ProjectsIndex.new(self)
+      end
     end
   end
 end

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -21,6 +21,7 @@ module Enginn
     # @return [Faraday::Connection]
     def connection
       @connection ||= Faraday.new(BASE_URL) do |conn|
+        conn.adapter @adapter
         conn.request :authorization, 'Bearer', -> { @api_token }
         conn.request :json
         conn.response :json

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -33,12 +33,12 @@ module Enginn
       @connection
     end
 
-    def projects(arg = nil)
-      case arg
+    def projects(discriminant = nil)
+      case discriminant
       when String
-        Project.new(self, { uid: arg })
+        Project.new(self, { uid: discriminant })
       when Hash
-        ProjectsIndex.new(self, arg)
+        ProjectsIndex.new(self, discriminant)
       else
         ProjectsIndex.new(self)
       end

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -29,7 +29,8 @@ module Enginn
         conn.response :json
         conn.response :raise_error
       end
-      block_given? ? yield(@connection) : @connection
+      yield(@connection) if block_given?
+      @connection
     end
 
     def projects(arg = nil)

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -51,7 +51,7 @@ module Enginn
       when String
         Project.new(self, { uid: discriminant })
       when Hash
-        ProjectsIndex.new(self, discriminant)
+        ProjectsIndex.new(self).where(discriminant)
       else
         ProjectsIndex.new(self)
       end

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -31,30 +31,11 @@ module Enginn
       @connection
     end
 
-    # Retrieve one or multiple project(s).
+    # Retrieve the projects the account have access to.
     #
-    # If no discriminant is given, return a {Enginn::ProjectsIndex} with no
-    # filters. If a Hash is given, return a {Enginn::ProjectsIndex} filtered
-    # with the given Hash.
-    # If a String is given, return a {Enginn::Project} with its UID set as the
-    # given String.
-    #
-    # @example
-    #   client.projects # => Enginn::ProjectsIndex
-    #   client.projects(name: 'New World') # => Enginn::ProjectsIndex
-    #   client.projects('<uid>') # => Enginn::Project
-    #
-    # @param discriminant [nil, String, Hash]
-    # @return [Enginn::Project, Enginn::ProjectsIndex]
-    def projects(discriminant = nil)
-      case discriminant
-      when String
-        Project.new(self, { uid: discriminant })
-      when Hash
-        ProjectsIndex.new(self).where(discriminant)
-      else
-        ProjectsIndex.new(self)
-      end
+    # @return [Enginn::ProjectsIndex]
+    def projects
+      ProjectsIndex.new(self)
     end
   end
 end

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -8,20 +8,17 @@ module Enginn
 
     attr_reader :api_token, :adapter
 
-    # Public: Create a new client.
-    #
-    # :api_token - The String API token to use for this client.
-    # :adapter   - The Symbol Faraday adapter to use (default: Faraday.default_adapter)
+    # @param api_token [String] The API token to use
+    # @param adapter [Symbol] The Faraday adapter to use
     def initialize(api_token:, adapter: Faraday.default_adapter)
       @api_token = api_token
       @adapter = adapter
     end
 
-    # Public: Get a Faraday connection to the API with relevant middlewares (authorization and JSON)
+    # Get a connection to the API.
     #
-    # If a block is given, yields the Faraday::Connection.
-    #
-    # Returns a Faraday::Connection.
+    # @yieldparam connection [Faraday::Connection] if a block is given
+    # @return [Faraday::Connection]
     def connection
       @connection ||= Faraday.new(BASE_URL) do |conn|
         conn.request :authorization, 'Bearer', -> { @api_token }
@@ -33,6 +30,21 @@ module Enginn
       @connection
     end
 
+    # Retrieve one or multiple project(s).
+    #
+    # If no discriminant is given, return a {Enginn::ProjectsIndex} with no
+    # filters. If a Hash is given, return a {Enginn::ProjectsIndex} filtered
+    # with the given Hash.
+    # If a String is given, return a {Enginn::Project} with its UID set as the
+    # given String.
+    #
+    # @example
+    #   client.projects # => Enginn::ProjectsIndex
+    #   client.projects(name: 'New World') # => Enginn::ProjectsIndex
+    #   client.projects('<uid>') # => Enginn::Project
+    #
+    # @param discriminant [nil, String, Hash]
+    # @return [Enginn::Project, Enginn::ProjectsIndex]
     def projects(discriminant = nil)
       case discriminant
       when String

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -27,7 +27,6 @@ module Enginn
         conn.request :authorization, 'Bearer', -> { @api_token }
         conn.request :json
         conn.response :json
-        conn.response :logger
         conn.response :raise_error
       end
       block_given? ? yield(@connection) : @connection

--- a/lib/enginn/client.rb
+++ b/lib/enginn/client.rb
@@ -25,7 +25,7 @@ module Enginn
         conn.request :authorization, 'Bearer', -> { @api_token }
         conn.request :json
         conn.response :json
-        conn.response :raise_error
+        conn.response :enginn_raise_error
       end
       yield(@connection) if block_given?
       @connection

--- a/lib/enginn/error.rb
+++ b/lib/enginn/error.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Enginn
+  class Error < StandardError; end
+
+  # Map Enginn errors to Faraday's while keeping Enginn::Error inheriting from
+  # StandardError.
+  class HTTPError < Faraday::Error; end
+  class ClientError < HTTPError; end
+  class ServerError < HTTPError; end
+  class BadRequestError < ClientError; end
+  class UnauthorizedError < ClientError; end
+  class ForbiddenError < ClientError; end
+  class ResourceNotFound < ClientError; end
+  class ProxyAuthError < ClientError; end
+  class ConflictError < ClientError; end
+  class UnprocessableEntityError < ClientError; end
+  class NilStatusError < ServerError; end
+
+  # Override the Faraday::Response::RaiseError middleware to raise Enginn
+  # errors instead of Faraday's
+  # (see https://github.com/lostisland/faraday -> lib/faraday/error.rb)
+  #
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/MethodLength
+  class RaiseError < Faraday::Response::RaiseError
+    def on_complete(env)
+      case env[:status]
+      when 400
+        raise Enginn::BadRequestError, response_values(env)
+      when 401
+        raise Enginn::UnauthorizedError, response_values(env)
+      when 403
+        raise Enginn::ForbiddenError, response_values(env)
+      when 404
+        raise Enginn::ResourceNotFound, response_values(env)
+      when 407
+        # mimic the behavior that we get with proxy requests with HTTPS
+        msg = %(407 "Proxy Authentication Required")
+        raise Enginn::ProxyAuthError.new(msg, response_values(env))
+      when 409
+        raise Enginn::ConflictError, response_values(env)
+      when 422
+        raise Enginn::UnprocessableEntityError, response_values(env)
+      when ClientErrorStatuses
+        raise Enginn::ClientError, response_values(env)
+      when ServerErrorStatuses
+        raise Enginn::ServerError, response_values(env)
+      when nil
+        raise Enginn::NilStatusError, response_values(env)
+      end
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
+
+  Faraday::Response.register_middleware(enginn_raise_error: Enginn::RaiseError)
+end

--- a/lib/enginn/project.rb
+++ b/lib/enginn/project.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 module Enginn
-  class Project
+  class Project < Resource
+    def self.path
+      'projects'
+    end
+
     def initialize(client, attributes = {})
-      @client = client
-      @attributes = {}
-      sync_attributes_with(attributes)
+      super(client, nil, attributes)
     end
 
     def characters(arg = nil)
@@ -20,39 +22,8 @@ module Enginn
     end
 
     def route
-      "projects/#{@attributes[:uid]}"
-    end
-
-    def fetch!
-      result = request(:get)[:result]
-      sync_attributes_with(result)
-      self
-    end
-
-    def save!
-      result = request(:patch)[:result]
-      sync_attributes_with(result)
-      self
-    end
-
-    def inspect
-      "#<#{self.class} #{@attributes.map { |name, value| "@#{name}=#{value}" }.join(', ')}>"
-    end
-
-    private
-
-    def sync_attributes_with(hash)
-      @attributes.merge!(hash)
-      @attributes.each do |attribute, value|
-        instance_variable_set("@#{attribute}", value)
-        self.class.define_method(attribute) { @attributes[attribute] }
-        self.class.define_method("#{attribute}=") { |arg| @attributes[attribute] = arg }
-      end
-    end
-
-    def request(method)
-      response = @client.connection.public_send(method, "projects/#{@attributes[:uid]}")
-      JSON.parse(JSON[response.body], symbolize_names: true)
+      # TODO: replace `uid` with `id` when PK migration is completed
+      "#{self.class.path}/#{@attributes[:uid]}"
     end
   end
 end

--- a/lib/enginn/project.rb
+++ b/lib/enginn/project.rb
@@ -10,14 +10,45 @@ module Enginn
       super(client, nil, attributes)
     end
 
-    def characters(arg = nil)
-      case arg
+    # Retrieve one or multiple characters(s).
+    #
+    # If no discriminant is given, return a {Enginn::CharactersIndex} with no
+    # filters. If a Hash is given, return a {Enginn::CharactersIndex} filtered
+    # with the given Hash.
+    # If a String is given, return a {Enginn::Character} with its ID set as the
+    # given String.
+    #
+    # @param discriminant [nil, String, Hash]
+    # @return [Enginn::Character, Enginn::CharactersIndex]
+    def characters(discriminant = nil)
+      case discriminant
       when String
-        Character.new(@client, self, { id: arg })
+        Character.new(self, { id: discriminant })
       when Hash
-        CharactersIndex.new(@client, self, arg)
+        CharactersIndex.new(self, discriminant)
       else
-        CharactersIndex.new(@client, self)
+        CharactersIndex.new(self)
+      end
+    end
+
+    # Retrieve one or multiple takes(s).
+    #
+    # If no discriminant is given, return a {Enginn::TakesIndex} with no
+    # filters. If a Hash is given, return a {Enginn::TakesIndex} filtered
+    # with the given Hash.
+    # If a String is given, return a {Enginn::Take} with its ID set as the
+    # given String.
+    #
+    # @param discriminant [nil, String, Hash]
+    # @return [Enginn::Take, Enginn::TakesIndex]
+    def takes(discriminant = nil)
+      case discriminant
+      when String
+        Take.new(self, { id: discriminant })
+      when Hash
+        TakesIndex.new(self, discriminant)
+      else
+        TakesIndex.new(self)
       end
     end
 

--- a/lib/enginn/project.rb
+++ b/lib/enginn/project.rb
@@ -28,8 +28,7 @@ module Enginn
 
     # @api private
     def route
-      # TODO: replace `uid` with `id` when PK migration is completed
-      "#{self.class.path}/#{@attributes[:uid]}"
+      "#{self.class.path}/#{@attributes[:id]}"
     end
   end
 end

--- a/lib/enginn/project.rb
+++ b/lib/enginn/project.rb
@@ -6,8 +6,12 @@ module Enginn
       'projects'
     end
 
+    attr_reader :client
+
+    # @param client [Enginn::Client] The client to use with this project and its sub-resources
     def initialize(client, attributes = {})
-      super(client, nil, attributes)
+      @client = client
+      super(self, attributes)
     end
 
     # Retrieve one or multiple characters(s).
@@ -52,6 +56,7 @@ module Enginn
       end
     end
 
+    # @api private
     def route
       # TODO: replace `uid` with `id` when PK migration is completed
       "#{self.class.path}/#{@attributes[:uid]}"

--- a/lib/enginn/project.rb
+++ b/lib/enginn/project.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Enginn
+  class Project
+    def initialize(client, attributes = {})
+      @client = client
+      @attributes = {}
+      sync_attributes_with(attributes)
+    end
+
+    def characters(arg = nil)
+      case arg
+      when String
+        Character.new(@client, self, { id: arg })
+      when Hash
+        CharactersIndex.new(@client, self, arg)
+      else
+        CharactersIndex.new(@client, self)
+      end
+    end
+
+    def route
+      "projects/#{@attributes[:uid]}"
+    end
+
+    def fetch!
+      result = request(:get)[:result]
+      sync_attributes_with(result)
+      self
+    end
+
+    def save!
+      result = request(:patch)[:result]
+      sync_attributes_with(result)
+      self
+    end
+
+    def inspect
+      "#<#{self.class} #{@attributes.map { |name, value| "@#{name}=#{value}" }.join(', ')}>"
+    end
+
+    private
+
+    def sync_attributes_with(hash)
+      @attributes.merge!(hash)
+      @attributes.each do |attribute, value|
+        instance_variable_set("@#{attribute}", value)
+        self.class.define_method(attribute) { @attributes[attribute] }
+        self.class.define_method("#{attribute}=") { |arg| @attributes[attribute] = arg }
+      end
+    end
+
+    def request(method)
+      response = @client.connection.public_send(method, "projects/#{@attributes[:uid]}")
+      JSON.parse(JSON[response.body], symbolize_names: true)
+    end
+  end
+end

--- a/lib/enginn/project.rb
+++ b/lib/enginn/project.rb
@@ -14,46 +14,16 @@ module Enginn
       super(self, attributes)
     end
 
-    # Retrieve one or multiple characters(s).
-    #
-    # If no discriminant is given, return a {Enginn::CharactersIndex} with no
-    # filters. If a Hash is given, return a {Enginn::CharactersIndex} filtered
-    # with the given Hash.
-    # If a String is given, return a {Enginn::Character} with its ID set as the
-    # given String.
-    #
-    # @param discriminant [nil, String, Hash]
-    # @return [Enginn::Character, Enginn::CharactersIndex]
-    def characters(discriminant = nil)
-      case discriminant
-      when String
-        Character.new(self, { id: discriminant })
-      when Hash
-        CharactersIndex.new(self, discriminant)
-      else
-        CharactersIndex.new(self)
-      end
+    # Retrieve the characters present in this project.
+    # @return [Enginn::CharactersIndex]
+    def characters
+      CharactersIndex.new(self)
     end
 
-    # Retrieve one or multiple takes(s).
-    #
-    # If no discriminant is given, return a {Enginn::TakesIndex} with no
-    # filters. If a Hash is given, return a {Enginn::TakesIndex} filtered
-    # with the given Hash.
-    # If a String is given, return a {Enginn::Take} with its ID set as the
-    # given String.
-    #
-    # @param discriminant [nil, String, Hash]
-    # @return [Enginn::Take, Enginn::TakesIndex]
-    def takes(discriminant = nil)
-      case discriminant
-      when String
-        Take.new(self, { id: discriminant })
-      when Hash
-        TakesIndex.new(self, discriminant)
-      else
-        TakesIndex.new(self)
-      end
+    # Retrieve the takes present in this project.
+    # @return [Enginn::TakesIndex]
+    def takes
+      TakesIndex.new(self)
     end
 
     # @api private

--- a/lib/enginn/projects_index.rb
+++ b/lib/enginn/projects_index.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Enginn
+  class ProjectsIndex
+    include Enumerable
+
+    def initialize(client, filters = {})
+      @client = client
+      @filters = filters || {}
+      @pagination = { current: 1 }
+    end
+
+    def each(&block)
+      fetch! if @pagination[:last].nil? || @pagination[:current] <= @pagination[:last]
+      @collection.each(&block)
+    end
+
+    def page(page)
+      @pagination[:current] = page
+      self
+    end
+
+    def per(per)
+      @pagination[:per] = per
+      self
+    end
+
+    def filters(filters)
+      @filters = filters || {}
+      self
+    end
+
+    def fetch!
+      pagination = "per=#{@pagination[:per]}&page=#{@pagination[:current]}"
+      filters = @filters.map { |filter, val| "q[#{filter}]=#{val}" }.join('&')
+      response = @client.connection.get("projects?#{pagination}&#{filters}")
+      body = JSON.parse(JSON[response.body], symbolize_names: true)
+
+      @pagination = body[:pagination]
+      @collection = body[:result].map { |attributes| Project.new(@client, attributes) }
+
+      self
+    end
+
+    def inspect
+      attributes = instance_variables.map do |var|
+        "#{var}=#{instance_variable_get(var)}"
+      end
+      "#<#{self.class} #{attributes.join(', ')}>"
+    end
+  end
+end

--- a/lib/enginn/projects_index.rb
+++ b/lib/enginn/projects_index.rb
@@ -6,8 +6,12 @@ module Enginn
       Project
     end
 
-    def initialize(client, filters = nil)
-      super(client, nil, filters)
+    attr_reader :client
+
+    # @param client [Enginn::Client] The client to use with this project and resources
+    def initialize(client)
+      @client = client
+      super(self)
     end
 
     def route
@@ -15,10 +19,6 @@ module Enginn
     end
 
     def fetch!
-      # HACK: needed to override the way individual resources are initialized
-      # because Project#initiliaze only take 2 arguments.
-      # REVIEW: Should we use keywords arguments for Resource#initiliaze instead ?
-      # Or accepts any *args ?
       response = request
       @pagination = response[:pagination]
       @collection = response[:result].map do |attributes|

--- a/lib/enginn/projects_index.rb
+++ b/lib/enginn/projects_index.rb
@@ -2,6 +2,7 @@
 
 module Enginn
   class ProjectsIndex < ResourceIndex
+    # @see ResourceIndex.resource
     def self.resource
       Project
     end
@@ -14,10 +15,7 @@ module Enginn
       super(self)
     end
 
-    def route
-      'projects'
-    end
-
+    # @see ResourceIndex#fetch!
     def fetch!
       response = request
       @pagination = response[:pagination]
@@ -25,6 +23,11 @@ module Enginn
         self.class.resource.new(@client, attributes)
       end
       self
+    end
+
+    # @api private
+    def route
+      'projects'
     end
   end
 end

--- a/lib/enginn/projects_index.rb
+++ b/lib/enginn/projects_index.rb
@@ -14,10 +14,11 @@ module Enginn
       'projects'
     end
 
-    # HACK: needed to override the way individual resources are initialized
-    # because Project#initiliaze only take 2 arguments.
-    # REVIEW: Should we use keywords arguments for Resource#initiliaze instead ?
     def fetch!
+      # HACK: needed to override the way individual resources are initialized
+      # because Project#initiliaze only take 2 arguments.
+      # REVIEW: Should we use keywords arguments for Resource#initiliaze instead ?
+      # Or accepts any *args ?
       response = request
       @pagination = response[:pagination]
       @collection = response[:result].map do |attributes|

--- a/lib/enginn/resource.rb
+++ b/lib/enginn/resource.rb
@@ -2,18 +2,6 @@
 
 module Enginn
   class Resource
-    def self.path
-      raise 'not implemented'
-    end
-
-    # def self.fetch(client, project, attributes)
-    #   new(client, project, attributes).fetch!
-    # end
-
-    # def self.create(client, project, attributes)
-    #   new(client, project, attributes).create!
-    # end
-
     def initialize(client, project, attributes = {})
       @client = client
       @project = project
@@ -28,8 +16,13 @@ module Enginn
     end
 
     def save!
-      result = request(:patch)[:result]
-      sync_attributes_with(result)
+      response = request(@attributes[:id].nil? ? :post : :patch)
+      sync_attributes_with(response[:result])
+      self
+    end
+
+    def destroy!
+      request(:delete)
       self
     end
 
@@ -38,7 +31,7 @@ module Enginn
     end
 
     def inspect
-      "#<#{self.class} #{@attributes.map { |name, value| "@#{name}=#{value}" }.join(', ')}>"
+      "#<#{self.class} #{@attributes.map { |name, value| "@#{name}=#{value.inspect}" }.join(', ')}>"
     end
 
     private
@@ -53,7 +46,8 @@ module Enginn
     end
 
     def request(method)
-      response = @client.connection.public_send(method, route, @attributes)
+      params = %i[post patch].include?(method) ? @attributes : {}
+      response = @client.connection.public_send(method, route, params)
       JSON.parse(JSON[response.body], symbolize_names: true)
     end
   end

--- a/lib/enginn/resource.rb
+++ b/lib/enginn/resource.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Enginn
+  class Resource
+    def self.path
+      raise 'not implemented'
+    end
+
+    # def self.fetch(client, project, attributes)
+    #   new(client, project, attributes).fetch!
+    # end
+
+    # def self.create(client, project, attributes)
+    #   new(client, project, attributes).create!
+    # end
+
+    def initialize(client, project, attributes = {})
+      @client = client
+      @project = project
+      @attributes = {}
+      sync_attributes_with(attributes)
+    end
+
+    def fetch!
+      result = request(:get)[:result]
+      sync_attributes_with(result)
+      self
+    end
+
+    def save!
+      result = request(:patch)[:result]
+      sync_attributes_with(result)
+      self
+    end
+
+    def route
+      "#{@project.route}/#{self.class.path}/#{@attributes[:id]}"
+    end
+
+    def inspect
+      "#<#{self.class} #{@attributes.map { |name, value| "@#{name}=#{value}" }.join(', ')}>"
+    end
+
+    private
+
+    def sync_attributes_with(hash)
+      @attributes.merge!(hash)
+      @attributes.each do |attribute, value|
+        instance_variable_set("@#{attribute}", value)
+        self.class.define_method(attribute) { @attributes[attribute] }
+        self.class.define_method("#{attribute}=") { |arg| @attributes[attribute] = arg }
+      end
+    end
+
+    def request(method)
+      response = @client.connection.public_send(method, route, @attributes)
+      JSON.parse(JSON[response.body], symbolize_names: true)
+    end
+  end
+end

--- a/lib/enginn/resource.rb
+++ b/lib/enginn/resource.rb
@@ -38,14 +38,12 @@ module Enginn
       raise NotImplementedError
     end
 
-    attr_reader :client, :project
+    attr_reader :project
     attr_accessor :attributes
 
-    # @param client [Enginn::Client] The client that will be used for this resource
     # @param project [Enginn::Project] The parent project of this resource
     # @param attributes [Hash] The attributes to initialize the resource with
-    def initialize(client, project, attributes = {})
-      @client = client
+    def initialize(project, attributes = {})
       @project = project
       @attributes = {}
       sync_attributes_with(attributes || {})
@@ -98,8 +96,9 @@ module Enginn
     end
 
     def request(method)
-      params = %i[post patch].include?(method) ? @attributes : {}
-      response = @client.connection.public_send(method, route, params)
+      resource_name = self.class.name.split('::').last.downcase
+      params = %i[post patch].include?(method) ? { resource_name => @attributes } : {}
+      response = @project.client.connection.public_send(method, route, params)
       JSON.parse(JSON[response.body], symbolize_names: true)
     end
   end

--- a/lib/enginn/resource.rb
+++ b/lib/enginn/resource.rb
@@ -11,7 +11,7 @@ module Enginn
   # instance method.
   #
   # @example
-  #   character = Enginn::Character(client, project, { id: 42 })
+  #   character = Enginn::Character(project, { id: 42 })
   #   character.name # NoMethodError
   #   character.fetch!
   #   character.name # => 'Rocky'
@@ -22,7 +22,7 @@ module Enginn
   # creation of a new Resource.
   #
   # @example
-  #   color = Enginn::Color.new(client, project, { code: '#16161D' })
+  #   color = Enginn::Color.new(project, { code: '#16161D' })
   #   color.save! # POST request (i.e. a new color created)
   #   color.id # => 24
   #   color.name = 'Eigengrau'

--- a/lib/enginn/resource.rb
+++ b/lib/enginn/resource.rb
@@ -1,7 +1,39 @@
 # frozen_string_literal: true
 
 module Enginn
+  # A Resource can be a Character, a Take, or anything described in the
+  # Enginn API doc (https://app.enginn.tech/api/docs).
+  #
+  # A Resource depends on a Client that will be used for actual HTTP operations
+  # and is relative to a parent Project (see {#initialize} parameters). When a
+  # Resource is fetched through {#fetch!} or {#save!}, any received attributes
+  # from the API is synced with the object such as it is available as an
+  # instance method.
+  #
+  # @example
+  #   character = Enginn::Character(client, project, { id: 42 })
+  #   character.name # NoMethodError
+  #   character.fetch!
+  #   character.name # => 'Rocky'
+  #
+  # A Resource whose attributes include an ID will be considered as already
+  # existing and as such, subsequent calls to {#save!} will issue a PATCH
+  # request. Otherwise, a POST request will be issued instead, allowing the
+  # creation of a new Resource.
+  #
+  # @example
+  #   color = Enginn::Color.new(client, project, { code: '#16161D' })
+  #   color.save! # POST request / new color created
+  #   color.id # => 24
+  #   color.name = 'Eigengrau'
+  #   color.save! # PATCH request / the color is updated
   class Resource
+    attr_reader :client, :project
+    attr_accessor :attributes
+
+    # @param client [Enginn::Client] The client that will be used for this resource
+    # @param project [Enginn::Project] The parent project of this resource
+    # @param attributes [Hash] The attributes to initialize the resource with
     def initialize(client, project, attributes = {})
       @client = client
       @project = project

--- a/lib/enginn/resource_index.rb
+++ b/lib/enginn/resource_index.rb
@@ -2,17 +2,13 @@
 
 module Enginn
   class ResourceIndex
-    def self.resource
-      raise 'not implemented'
-    end
-
     def self.path
       resource.path
     end
 
     include Enumerable
 
-    def initialize(client, project, filters = {})
+    def initialize(client, project, filters = nil)
       @client = client
       @project = project
       @filters = filters || {}

--- a/lib/enginn/resource_index.rb
+++ b/lib/enginn/resource_index.rb
@@ -9,12 +9,13 @@ module Enginn
   #
   # Actual API requests are only issued when the {#each} method (or any method
   # from Enumerable) is called. While {#each}-ing, new API request will be
-  # issued when the end of a page is reached.
+  # issued when the end of a page is reached. Note that when using {#page}, only
+  # the given page is reached for.
   # One can also force fetching manually using {#fetch!}.
   #
   # @example
-  #   characters = project.characters.where(scene_id: '12345').per(50)
-  #   characters.map(&:name)
+  #   takes = project.takes.where(synthesis_text_cont: 'hello')
+  #   takes.map(&:character_name)
   #
   # @abstract Override the {.resource} method to implement.
   class ResourceIndex

--- a/lib/enginn/resource_index.rb
+++ b/lib/enginn/resource_index.rb
@@ -34,14 +34,10 @@ module Enginn
 
     include Enumerable
 
-    attr_reader :client, :project, :filters, :pagination
+    attr_reader :project, :filters, :pagination
 
-    # @param client [Enginn::Client] The client to use
     # @param project [Enginn::Project] The parent project of the indexed resource
-    # @param filters [Hash, nil] An optional Hash of filters (see {#where})
-    # TODO: remove `filters` from constructor to enforce consistency and use of #where
-    def initialize(client, project, filters = nil)
-      @client = client
+    def initialize(project)
       @project = project
       @filters = filters || {}
       @pagination = { current: 1 }
@@ -83,7 +79,7 @@ module Enginn
       response = request
       @pagination = response[:pagination]
       @collection = response[:result].map do |attributes|
-        self.class.resource.new(@client, @project, attributes)
+        self.class.resource.new(@project, attributes)
       end
       self
     end
@@ -105,7 +101,7 @@ module Enginn
     private
 
     def request
-      response = @client.connection.get(route, {
+      response = @project.client.connection.get(route, {
         per: @pagination[:per],
         page: @pagination[:current],
         q: @filters

--- a/lib/enginn/resource_index.rb
+++ b/lib/enginn/resource_index.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Enginn
+  class ResourceIndex
+    def self.resource
+      raise 'not implemented'
+    end
+
+    def self.path
+      resource.path
+    end
+
+    include Enumerable
+
+    def initialize(client, project, filters = {})
+      @client = client
+      @project = project
+      @filters = filters || {}
+      @pagination = { current: 1 }
+    end
+
+    def each(&block)
+      fetch! if @pagination[:last].nil? || @pagination[:current] <= @pagination[:last]
+      @collection.each(&block)
+    end
+
+    def page(page)
+      @pagination[:current] = page
+      self
+    end
+
+    def per(per)
+      @pagination[:per] = per
+      self
+    end
+
+    def filters(filters)
+      @filters = filters || {}
+      self
+    end
+
+    def route
+      "#{@project.route}/#{self.class.path}"
+    end
+
+    def fetch!
+      response = request
+      @pagination = response[:pagination]
+      @collection = response[:result].map do |attributes|
+        self.class.resource.new(@client, @project, attributes)
+      end
+      self
+    end
+
+    def inspect
+      attributes = instance_variables.map do |var|
+        "#{var}=#{instance_variable_get(var)}"
+      end
+      "#<#{self.class} #{attributes.join(', ')}>"
+    end
+
+    private
+
+    def request
+      pagination = "per=#{@pagination[:per]}&page=#{@pagination[:current]}"
+      filters = @filters.map { |filter, val| "q[#{filter}]=#{val}" }.join('&')
+      response = @client.connection.get("#{route}?#{pagination}&#{filters}")
+      JSON.parse(JSON[response.body], symbolize_names: true)
+    end
+  end
+end

--- a/lib/enginn/resource_index.rb
+++ b/lib/enginn/resource_index.rb
@@ -18,7 +18,7 @@ module Enginn
   #
   # @abstract Override the {.resource} method to implement.
   class ResourceIndex
-    # Define the type of {Enginn::Resource} to use with this {Enginn::ResourceIndex}.
+    # Define the type of {Enginn::Resource} to use with this kind of {Enginn::ResourceIndex}.
     #
     # @api private
     # @return [Enginn::Resource]
@@ -36,8 +36,8 @@ module Enginn
 
     attr_reader :client, :project, :filters, :pagination
 
-    # @param client [Enginn::Client] The {Enginn::Client} to use
-    # @param project [Enginn::Project] The parent {Enginn::Project} of the indexed resource
+    # @param client [Enginn::Client] The client to use
+    # @param project [Enginn::Project] The parent project of the indexed resource
     # @param filters [Hash, nil] An optional Hash of filters (see {#where})
     # TODO: remove `filters` from constructor to enforce consistency and use of #where
     def initialize(client, project, filters = nil)
@@ -101,10 +101,11 @@ module Enginn
     private
 
     def request
-      # TODO: refactor params using native Faraday params syntax
-      pagination = "per=#{@pagination[:per]}&page=#{@pagination[:current]}"
-      filters = @filters.map { |filter, val| "q[#{filter}]=#{val}" }.join('&')
-      response = @client.connection.get("#{route}?#{pagination}&#{filters}")
+      response = @client.connection.get(route, {
+        per: @pagination[:per],
+        page: @pagination[:page],
+        q: @filters
+      })
       JSON.parse(JSON[response.body], symbolize_names: true)
     end
   end

--- a/lib/enginn/resource_index.rb
+++ b/lib/enginn/resource_index.rb
@@ -1,13 +1,45 @@
 # frozen_string_literal: true
 
 module Enginn
+  # A {ResourceIndex} is a collection of fetchable {Resource}.
+  #
+  # It can be filtered and paginated through the chainable methods {#per},
+  # {#page}, and {#where}. It also includes the Enumerable module so methods
+  # such as {#each}, #map or #to_a are available.
+  #
+  # Actual API requests are only issued when the {#each} method (or any method
+  # from Enumerable) is called. While {#each}-ing, new API request will be
+  # issued when the end of a page is reached.
+  # One can also force fetching manually using {#fetch!}.
+  #
+  # @example
+  #   characters = project.characters.where(scene_id: '12345').per(50)
+  #   characters.map(&:name)
+  #
+  # @abstract Override the {.resource} method to implement.
   class ResourceIndex
+    # Define the type of {Enginn::Resource} to use with this {Enginn::ResourceIndex}.
+    #
+    # @api private
+    # @return [Enginn::Resource]
+    def self.resource
+      raise NotImplementedError # REVIEW: not sure this is intended to be directly used...
+    end
+
+    # @api private
+    # @return [String]
     def self.path
       resource.path
     end
 
     include Enumerable
 
+    attr_reader :client, :project, :filters, :pagination
+
+    # @param client [Enginn::Client] The {Enginn::Client} to use
+    # @param project [Enginn::Project] The parent {Enginn::Project} of the indexed resource
+    # @param filters [Hash, nil] An optional Hash of filters (see {#where})
+    # TODO: remove `filters` from constructor to enforce consistency and use of #where
     def initialize(client, project, filters = nil)
       @client = client
       @project = project
@@ -15,30 +47,34 @@ module Enginn
       @pagination = { current: 1 }
     end
 
+    # @yieldparam item [Enginn::Resource]
     def each(&block)
-      fetch! if @pagination[:last].nil? || @pagination[:current] <= @pagination[:last]
+      fetch! if @pagination[:last].nil? || @pagination[:current] < @pagination[:last]
       @collection.each(&block)
     end
 
+    # @param page [Integer] The page number
+    # @return [Enginn::ResourceIndex]
     def page(page)
       @pagination[:current] = page
       self
     end
 
+    # @param per [Integer] The number of items per page
+    # @return [Enginn::ResourceIndex]
     def per(per)
       @pagination[:per] = per
       self
     end
 
-    def filters(filters)
-      @filters = filters || {}
+    # @param filters [Hash] Filters as you would use them in the `q` object with the API.
+    # @return [Enginn::ResourceIndex]
+    def where(filters)
+      @filters.merge!(filters || {})
       self
     end
 
-    def route
-      "#{@project.route}/#{self.class.path}"
-    end
-
+    # @return [Enginn::ResourceIndex]
     def fetch!
       response = request
       @pagination = response[:pagination]
@@ -48,6 +84,7 @@ module Enginn
       self
     end
 
+    # @return [String]
     def inspect
       attributes = instance_variables.map do |var|
         "#{var}=#{instance_variable_get(var)}"
@@ -55,9 +92,16 @@ module Enginn
       "#<#{self.class} #{attributes.join(', ')}>"
     end
 
+    # @api private
+    # @return [String]
+    def route
+      "#{@project.route}/#{self.class.path}"
+    end
+
     private
 
     def request
+      # TODO: refactor params using native Faraday params syntax
       pagination = "per=#{@pagination[:per]}&page=#{@pagination[:current]}"
       filters = @filters.map { |filter, val| "q[#{filter}]=#{val}" }.join('&')
       response = @client.connection.get("#{route}?#{pagination}&#{filters}")

--- a/lib/enginn/take.rb
+++ b/lib/enginn/take.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Enginn
+  class Take < Resource
+    def self.path
+      'takes'
+    end
+  end
+end

--- a/lib/enginn/takes_index.rb
+++ b/lib/enginn/takes_index.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Enginn
+  class TakesIndex < ResourceIndex
+    def self.resource
+      Take
+    end
+  end
+end

--- a/spec/enginn/client_spec.rb
+++ b/spec/enginn/client_spec.rb
@@ -27,5 +27,12 @@ RSpec.describe Enginn::Client do
     it 'does not set any filters on the index' do
       expect(client.projects.filters).to be_empty
     end
+
+    it 'does not make any request' do
+      connection = client.connection
+      allow(connection).to receive(:get)
+      client.projects
+      expect(connection).not_to have_received(:get)
+    end
   end
 end

--- a/spec/enginn/client_spec.rb
+++ b/spec/enginn/client_spec.rb
@@ -10,10 +10,8 @@ RSpec.describe Enginn::Client do
       end
     end
 
-    context 'when no block is given' do
-      it 'returns a Faraday::Connection object' do
-        expect(client.connection).to be_a(Faraday::Connection)
-      end
+    it 'returns a Faraday::Connection object' do
+      expect(client.connection).to be_a(Faraday::Connection)
     end
 
     it 'initializes the connection with the right base URL' do

--- a/spec/enginn/client_spec.rb
+++ b/spec/enginn/client_spec.rb
@@ -18,4 +18,36 @@ RSpec.describe Enginn::Client do
       expect(client.connection.url_prefix.to_s).to eq(described_class::BASE_URL)
     end
   end
+
+  describe '#projects' do
+    context 'when no argument is given' do
+      it 'returns a Enginn::ProjectsIndex instance' do
+        expect(client.projects).to be_a(Enginn::ProjectsIndex)
+      end
+
+      it 'does not set any filters on the index' do
+        expect(client.projects.filters).to be_empty
+      end
+    end
+
+    context 'when the argument is a Hash' do
+      it 'returns a Enginn::ProjectsIndex instance' do
+        expect(client.projects(name: 'Buzz')).to be_a(Enginn::ProjectsIndex)
+      end
+
+      it 'filters the index' do
+        expect(client.projects(name: 'Buzz').filters).to eq(name: 'Buzz')
+      end
+    end
+
+    context 'when the argument is a String' do
+      it 'returns a Enginn::Project instance' do
+        expect(client.projects('12345')).to be_a(Enginn::Project)
+      end
+
+      it 'sets the correct uid' do
+        expect(client.projects('12345').uid).to eq('12345')
+      end
+    end
+  end
 end

--- a/spec/enginn/client_spec.rb
+++ b/spec/enginn/client_spec.rb
@@ -20,34 +20,12 @@ RSpec.describe Enginn::Client do
   end
 
   describe '#projects' do
-    context 'when no argument is given' do
-      it 'returns a Enginn::ProjectsIndex instance' do
-        expect(client.projects).to be_a(Enginn::ProjectsIndex)
-      end
-
-      it 'does not set any filters on the index' do
-        expect(client.projects.filters).to be_empty
-      end
+    it 'returns a Enginn::ProjectsIndex instance' do
+      expect(client.projects).to be_a(Enginn::ProjectsIndex)
     end
 
-    context 'when the argument is a Hash' do
-      it 'returns a Enginn::ProjectsIndex instance' do
-        expect(client.projects(name: 'Buzz')).to be_a(Enginn::ProjectsIndex)
-      end
-
-      it 'filters the index' do
-        expect(client.projects(name: 'Buzz').filters).to eq(name: 'Buzz')
-      end
-    end
-
-    context 'when the argument is a String' do
-      it 'returns a Enginn::Project instance' do
-        expect(client.projects('12345')).to be_a(Enginn::Project)
-      end
-
-      it 'sets the correct uid' do
-        expect(client.projects('12345').uid).to eq('12345')
-      end
+    it 'does not set any filters on the index' do
+      expect(client.projects.filters).to be_empty
     end
   end
 end

--- a/spec/enginn/resource_index_spec.rb
+++ b/spec/enginn/resource_index_spec.rb
@@ -69,6 +69,79 @@ RSpec.describe Enginn::ResourceIndex do
     end
   end
 
+  describe '#fetch!' do
+    let(:fakes_index) { FakesIndex.new(project) }
+
+    context 'when the request has succeeded' do
+      before do
+        stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes") do |env|
+          ApiStub.new(env).response
+        end
+      end
+
+      it 'returns true' do
+        expect(fakes_index.fetch!).to be true
+      end
+    end
+
+    context 'when the request has failed' do
+      before do
+        stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes") do
+          [
+            500,
+            { 'Content-Type' => 'application/json' },
+            { error: { foo: 'this is an error' } }
+          ]
+        end
+      end
+
+      it 'raises an error' do
+        expect { fakes_index.fetch! }.to raise_error(Faraday::Error)
+      end
+    end
+  end
+
+  describe '#fetch' do
+    let(:fakes_index) { FakesIndex.new(project) }
+
+    context 'when the request has succeeded' do
+      before do
+        stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes") do |env|
+          ApiStub.new(env).response
+        end
+      end
+
+      it 'returns true' do
+        expect(fakes_index.fetch).to be true
+      end
+    end
+
+    context 'when the request has failed' do
+      before do
+        stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes") do
+          [
+            500,
+            { 'Content-Type' => 'application/json' },
+            { error: { foo: 'this is an error' } }
+          ]
+        end
+      end
+
+      it 'does not raise errors' do
+        expect { fakes_index.fetch }.not_to raise_error
+      end
+
+      it 'returns false' do
+        expect(fakes_index.fetch).to be false
+      end
+
+      it 'fills in #errors' do
+        fakes_index.fetch
+        expect(fakes_index.errors).not_to be_empty
+      end
+    end
+  end
+
   describe '#each' do
     let(:fakes_index) { FakesIndex.new(project) }
 

--- a/spec/enginn/resource_index_spec.rb
+++ b/spec/enginn/resource_index_spec.rb
@@ -61,16 +61,16 @@ RSpec.describe Enginn::ResourceIndex do
 
   describe '#initialize' do
     it 'sets the current page to 1' do
-      expect(FakesIndex.new(client, project).pagination[:current]).to eq(1)
+      expect(FakesIndex.new(project).pagination[:current]).to eq(1)
     end
 
     it 'sets empty filters' do
-      expect(FakesIndex.new(client, project).filters).to eq({})
+      expect(FakesIndex.new(project).filters).to eq({})
     end
   end
 
   describe '#each' do
-    let(:fakes_index) { FakesIndex.new(client, project) }
+    let(:fakes_index) { FakesIndex.new(project) }
 
     before do
       stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes") do |env|
@@ -92,7 +92,7 @@ RSpec.describe Enginn::ResourceIndex do
   end
 
   describe '#page' do
-    let(:fakes_index) { FakesIndex.new(client, project) }
+    let(:fakes_index) { FakesIndex.new(project) }
 
     it 'updates the current page' do
       fakes_index.page(2)
@@ -105,7 +105,7 @@ RSpec.describe Enginn::ResourceIndex do
   end
 
   describe '#per' do
-    let(:fakes_index) { FakesIndex.new(client, project) }
+    let(:fakes_index) { FakesIndex.new(project) }
 
     it 'updates the number of items per page' do
       fakes_index.per(10)
@@ -118,7 +118,7 @@ RSpec.describe Enginn::ResourceIndex do
   end
 
   describe '#where' do
-    let(:fakes_index) { FakesIndex.new(client, project) }
+    let(:fakes_index) { FakesIndex.new(project) }
 
     context 'when there is no existing filters' do
       it 'sets the filters to equal the given argument' do
@@ -143,7 +143,7 @@ RSpec.describe Enginn::ResourceIndex do
 
   describe '#inspect' do
     it 'returns a string' do
-      expect(FakesIndex.new(client, project).inspect).to be_a(String)
+      expect(FakesIndex.new(project).inspect).to be_a(String)
     end
   end
 end

--- a/spec/enginn/resource_index_spec.rb
+++ b/spec/enginn/resource_index_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# RSpec.describe Enginn::ResourceIndex do
+# end

--- a/spec/enginn/resource_index_spec.rb
+++ b/spec/enginn/resource_index_spec.rb
@@ -45,7 +45,7 @@ end
 RSpec.describe Enginn::ResourceIndex do
   let(:stubs) { Faraday::Adapter::Test::Stubs.new }
   let(:client) { Enginn::Client.new(api_token: '12345') }
-  let(:project) { Enginn::Project.new(client, { uid: 1 }) }
+  let(:project) { Enginn::Project.new(client, { id: 1 }) }
 
   before do
     client.connection do |conn|

--- a/spec/enginn/resource_index_spec.rb
+++ b/spec/enginn/resource_index_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Enginn::ResourceIndex do
       end
 
       it 'raises an error' do
-        expect { fakes_index.fetch! }.to raise_error(Faraday::Error)
+        expect { fakes_index.fetch! }.to raise_error(Enginn::HTTPError)
       end
     end
   end

--- a/spec/enginn/resource_index_spec.rb
+++ b/spec/enginn/resource_index_spec.rb
@@ -94,26 +94,24 @@ RSpec.describe Enginn::ResourceIndex do
   describe '#page' do
     let(:fakes_index) { FakesIndex.new(project) }
 
-    it 'updates the current page' do
-      fakes_index.page(2)
-      expect(fakes_index.pagination[:current]).to eq(2)
+    it 'returns a copy of the object' do
+      expect(fakes_index.page(2)).not_to be(fakes_index)
     end
 
-    it 'returns self' do
-      expect(fakes_index.page(2)).to be(fakes_index)
+    it 'updates the current page' do
+      expect(fakes_index.page(2).pagination[:current]).to eq(2)
     end
   end
 
   describe '#per' do
     let(:fakes_index) { FakesIndex.new(project) }
 
-    it 'updates the number of items per page' do
-      fakes_index.per(10)
-      expect(fakes_index.pagination[:per]).to eq(10)
+    it 'returns a copy of the object' do
+      expect(fakes_index.per(10)).not_to be(fakes_index)
     end
 
-    it 'returns self' do
-      expect(fakes_index.per(10)).to be(fakes_index)
+    it 'updates the number of items per page' do
+      expect(fakes_index.per(10).pagination[:per]).to eq(10)
     end
   end
 
@@ -122,22 +120,19 @@ RSpec.describe Enginn::ResourceIndex do
 
     context 'when there is no existing filters' do
       it 'sets the filters to equal the given argument' do
-        fakes_index.where(foo: 1)
-        expect(fakes_index.filters).to eq(foo: 1)
+        expect(fakes_index.where(foo: 1).filters).to eq(foo: 1)
       end
     end
 
     context 'when there are filters already' do
-      before { fakes_index.where(foo: 1) }
-
       it 'merges existing filters and new ones' do
-        fakes_index.where(bar: 2)
-        expect(fakes_index.filters).to eq(foo: 1, bar: 2)
+        index = fakes_index.where(foo: 1)
+        expect(index.where(bar: 2).filters).to eq(foo: 1, bar: 2)
       end
     end
 
-    it 'returns self' do
-      expect(fakes_index.where({})).to be(fakes_index)
+    it 'returns a copy of the object' do
+      expect(fakes_index.where(bar: 2)).not_to be(fakes_index)
     end
   end
 

--- a/spec/enginn/resource_index_spec.rb
+++ b/spec/enginn/resource_index_spec.rb
@@ -1,4 +1,149 @@
 # frozen_string_literal: true
 
-# RSpec.describe Enginn::ResourceIndex do
-# end
+class ApiStub
+  def initialize(env)
+    @env = env
+    @collection = [
+      { id: 1, name: 'Indiana', size: 'smol' },
+      { id: 2, name: 'Jones', size: 'big' }
+    ]
+  end
+
+  def response
+    [
+      200,
+      { 'Content-Type' => 'application/json' },
+      body
+    ]
+  end
+
+  private
+
+  def body
+    page = @env.params['page']&.to_i || 1
+    per = @env.params['per']&.to_i || 25
+    items = @collection.each_slice(per).to_a
+    {
+      result: items[page - 1],
+      pagination: { current: page, per: per, last: items.size, count: @collection.size }
+    }
+  end
+end
+
+class Fake < Enginn::Resource
+  def self.path
+    'fakes'
+  end
+end
+
+class FakesIndex < Enginn::ResourceIndex
+  def self.resource
+    Fake
+  end
+end
+
+RSpec.describe Enginn::ResourceIndex do
+  let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+  let(:client) { Enginn::Client.new(api_token: '12345') }
+  let(:project) { Enginn::Project.new(client, { uid: 1 }) }
+
+  before do
+    client.connection do |conn|
+      conn.adapter :test, stubs
+      # Uncomment to help debugging stubs
+      # conn.response :logger
+    end
+  end
+
+  after do
+    Faraday.default_connection = nil
+  end
+
+  describe '#initialize' do
+    it 'sets the current page to 1' do
+      expect(FakesIndex.new(client, project).pagination[:current]).to eq(1)
+    end
+
+    it 'sets empty filters' do
+      expect(FakesIndex.new(client, project).filters).to eq({})
+    end
+  end
+
+  describe '#each' do
+    let(:fakes_index) { FakesIndex.new(client, project) }
+
+    before do
+      stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes") do |env|
+        ApiStub.new(env).response
+      end
+    end
+
+    context 'when there is only one page' do
+      it 'yields all the items in the collection' do
+        expect(fakes_index.per(2).page(1).map(&:name)).to eq(%w[Indiana Jones])
+      end
+    end
+
+    context 'when there is multiple pages' do
+      it 'yields all the items in the collection' do
+        expect(fakes_index.per(1).map(&:name)).to eq(%w[Indiana Jones])
+      end
+    end
+  end
+
+  describe '#page' do
+    let(:fakes_index) { FakesIndex.new(client, project) }
+
+    it 'updates the current page' do
+      fakes_index.page(2)
+      expect(fakes_index.pagination[:current]).to eq(2)
+    end
+
+    it 'returns self' do
+      expect(fakes_index.page(2)).to be(fakes_index)
+    end
+  end
+
+  describe '#per' do
+    let(:fakes_index) { FakesIndex.new(client, project) }
+
+    it 'updates the number of items per page' do
+      fakes_index.per(10)
+      expect(fakes_index.pagination[:per]).to eq(10)
+    end
+
+    it 'returns self' do
+      expect(fakes_index.per(10)).to be(fakes_index)
+    end
+  end
+
+  describe '#where' do
+    let(:fakes_index) { FakesIndex.new(client, project) }
+
+    context 'when there is no existing filters' do
+      it 'sets the filters to equal the given argument' do
+        fakes_index.where(foo: 1)
+        expect(fakes_index.filters).to eq(foo: 1)
+      end
+    end
+
+    context 'when there are filters already' do
+      before { fakes_index.where(foo: 1) }
+
+      it 'merges existing filters and new ones' do
+        fakes_index.where(bar: 2)
+        expect(fakes_index.filters).to eq(foo: 1, bar: 2)
+      end
+    end
+
+    it 'returns self' do
+      expect(fakes_index.where({})).to be(fakes_index)
+    end
+  end
+
+  describe '#inspect' do
+    it 'returns a string' do
+      expect(FakesIndex.new(client, project).inspect).to be_a(String)
+    end
+  end
+end

--- a/spec/enginn/resource_spec.rb
+++ b/spec/enginn/resource_spec.rb
@@ -104,4 +104,10 @@ RSpec.describe Enginn::Resource do
     #   raise StandardError
     # end
   end
+
+  describe '#inspect' do
+    it 'returns a string' do
+      expect(FakeResource.new(client, project).inspect).to be_a(String)
+    end
+  end
 end

--- a/spec/enginn/resource_spec.rb
+++ b/spec/enginn/resource_spec.rb
@@ -7,48 +7,21 @@ class FakeResource < Enginn::Resource
 end
 
 RSpec.describe Enginn::Resource do
+  let(:stubs) { Faraday::Adapter::Test::Stubs.new }
   let(:client) { Enginn::Client.new(api_token: '12345') }
   let(:project) { Enginn::Project.new(client, id: 1) }
 
   before do
     client.connection do |conn|
-      conn.adapter :test do |stub|
-        stub.get("#{Enginn::Client::BASE_URL}/projects/1") do |_|
-          [
-            200,
-            { 'Content-Type': 'application/json' },
-            { result: { id: 1, name: 'Fake Project' } }
-          ]
-        end
-        stub.get("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
-          [
-            200,
-            { 'Content-Type': 'application/json' },
-            { result: { id: 42, name: 'Fake' } }
-          ]
-        end
-        stub.post("#{Enginn::Client::BASE_URL}/projects/1/fakes/") do |env|
-          [
-            201,
-            { 'Content-Type': 'application/json' },
-            { result: JSON.parse(env.body).merge(id: 42) }
-          ]
-        end
-        stub.patch("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |env|
-          [
-            200,
-            { 'Content-Type': 'application/json' },
-            { result: JSON.parse(env.body).merge(id: 42) }
-          ]
-        end
-        stub.delete("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
-          [
-            200,
-            { 'Content-Type': 'application/json' },
-            { result: nil }
-          ]
-        end
-      end
+      conn.adapter :test, stubs
+    end
+
+    stubs.get("#{Enginn::Client::BASE_URL}/projects/1") do |_|
+      [
+        200,
+        { 'Content-Type': 'application/json' },
+        { result: { id: 1, name: 'Fake Project' } }
+      ]
     end
   end
 
@@ -57,28 +30,137 @@ RSpec.describe Enginn::Resource do
   end
 
   describe '#fetch!' do
-    let(:resource) { FakeResource.new(project, { id: 42 }) }
-
-    before { resource.fetch! }
-
-    it 'synchronizes attributes' do
-      expect(resource.attributes).to include({ id: 42, name: 'Fake' })
+    before do
+      stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes/0") do |_|
+        [
+          404,
+          { 'Content-Type': 'application/json' },
+          { errors: { id: 'does not exist' } }
+        ]
+      end
+      stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { result: { id: 42, name: 'Fake' } }
+        ]
+      end
     end
 
-    it 'exposes attributes as instance methods' do
-      resource.attributes.each_key do |attr|
-        expect { resource.send(attr) }.not_to raise_error
+    let(:resource) { FakeResource.new(project, { id: 42 }) }
+
+    context 'when the request has succeeded' do
+      it 'returns true' do
+        expect(resource.fetch!).to be true
+      end
+
+      it 'synchronizes attributes' do
+        resource.fetch!
+        expect(resource.attributes).to include({ id: 42, name: 'Fake' })
+      end
+
+      it 'exposes attributes as instance methods' do
+        resource.fetch!
+        resource.attributes.each_key do |attr|
+          expect { resource.send(attr) }.not_to raise_error
+        end
+      end
+    end
+
+    context 'when the request has failed' do
+      it 'raises an error' do
+        resource.id = 0
+        expect { resource.fetch! }.to raise_error(Faraday::Error)
+      end
+    end
+  end
+
+  describe '#fetch' do
+    before do
+      stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes/0") do |_|
+        [
+          404,
+          { 'Content-Type': 'application/json' },
+          { errors: { id: 'does not exist' } }
+        ]
+      end
+      stubs.get("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { result: { id: 42, name: 'Fake' } }
+        ]
+      end
+    end
+
+    let(:resource) { FakeResource.new(project, { id: 42 }) }
+
+    context 'when the request has succeeded' do
+      it 'returns true' do
+        expect(resource.fetch).to be true
+      end
+
+      it 'synchronizes attributes' do
+        resource.fetch
+        expect(resource.attributes).to include({ id: 42, name: 'Fake' })
+      end
+
+      it 'exposes attributes as instance methods' do
+        resource.fetch
+        resource.attributes.each_key do |attr|
+          expect { resource.send(attr) }.not_to raise_error
+        end
+      end
+    end
+
+    context 'when the request has failed' do
+      before { resource.id = 0 }
+
+      it 'does not raise errors' do
+        expect { resource.fetch }.not_to raise_error
+      end
+
+      it 'returns false' do
+        expect(resource.fetch).to be false
+      end
+
+      it 'fill in #errors' do
+        resource.fetch
+        expect(resource.errors).not_to be_empty
       end
     end
   end
 
   describe '#save!' do
+    before do
+      stubs.post("#{Enginn::Client::BASE_URL}/projects/1/fakes/") do |env|
+        [
+          201,
+          { 'Content-Type': 'application/json' },
+          { result: JSON.parse(env.body).merge(id: 42) }
+        ]
+      end
+      stubs.patch("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { result: JSON.parse(env.body).merge(id: 42) }
+        ]
+      end
+      stubs.patch("#{Enginn::Client::BASE_URL}/projects/1/fakes/0") do |_|
+        [
+          422,
+          { 'Content-Type': 'application/json' },
+          { errors: { id: 'does not exist' } }
+        ]
+      end
+    end
+
     context 'when the resource has no ID' do
       let(:resource) { FakeResource.new(project, { name: 'Fake' }) }
 
-      before { resource.save! }
-
       it 'creates a new resource' do
+        resource.save!
         expect(resource.id).to eq(42)
       end
     end
@@ -86,23 +168,177 @@ RSpec.describe Enginn::Resource do
     context 'when the resource has an ID' do
       let(:resource) { FakeResource.new(project, { id: 42, name: 'Fake' }) }
 
-      before do
+      it 'updates the resource' do
         resource.name = 'New Name'
         resource.save!
+        expect(resource.name).to eq('New Name')
       end
+    end
+
+    context 'when the request has succeeded' do
+      let(:resource) { FakeResource.new(project, { name: 'Fake' }) }
+
+      it 'returns true' do
+        expect(resource.save!).to be true
+      end
+    end
+
+    context 'when the request has failed' do
+      let(:resource) { FakeResource.new(project, { id: 0 }) }
+
+      it 'raises an error' do
+        expect { resource.save! }.to raise_error(Faraday::Error)
+      end
+    end
+  end
+
+  describe '#save' do
+    before do
+      stubs.post("#{Enginn::Client::BASE_URL}/projects/1/fakes/") do |env|
+        [
+          201,
+          { 'Content-Type': 'application/json' },
+          { result: JSON.parse(env.body).merge(id: 42) }
+        ]
+      end
+      stubs.patch("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |env|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { result: JSON.parse(env.body).merge(id: 42) }
+        ]
+      end
+      stubs.patch("#{Enginn::Client::BASE_URL}/projects/1/fakes/0") do |_|
+        [
+          422,
+          { 'Content-Type': 'application/json' },
+          { errors: { id: 'does not exist' } }
+        ]
+      end
+    end
+
+    context 'when the resource has no ID' do
+      let(:resource) { FakeResource.new(project, { name: 'Fake' }) }
+
+      it 'creates a new resource' do
+        resource.save
+        expect(resource.id).to eq(42)
+      end
+    end
+
+    context 'when the resource has an ID' do
+      let(:resource) { FakeResource.new(project, { id: 42, name: 'Fake' }) }
 
       it 'updates the resource' do
+        resource.name = 'New Name'
+        resource.save
         expect(resource.name).to eq('New Name')
+      end
+    end
+
+    context 'when the request has succeeded' do
+      let(:resource) { FakeResource.new(project, { name: 'Fake' }) }
+
+      it 'returns true' do
+        expect(resource.save).to be true
+      end
+    end
+
+    context 'when the request has failed' do
+      let(:resource) { FakeResource.new(project, { id: 0 }) }
+
+      it 'does not raise errors' do
+        expect { resource.save }.not_to raise_error
+      end
+
+      it 'returns false' do
+        expect(resource.save).to be false
+      end
+
+      it 'fill in #errors' do
+        resource.save
+        expect(resource.errors).not_to be_empty
       end
     end
   end
 
   describe '#destroy!' do
-    pending 'How do we test/show resource destruction?'
+    before do
+      stubs.delete("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { result: nil }
+        ]
+      end
+      stubs.delete("#{Enginn::Client::BASE_URL}/projects/1/fakes/0") do |_|
+        [
+          503,
+          { 'Content-Type': 'application/json' },
+          { errors: { id: 'seriously, zero?' } }
+        ]
+      end
+    end
 
-    # it 'deletes the resource' do
-    #   raise StandardError
-    # end
+    context 'when the request has succeeded' do
+      let(:resource) { FakeResource.new(project, id: 42) }
+
+      it 'returns true' do
+        expect(resource.destroy!).to be true
+      end
+    end
+
+    context 'when the request has failed' do
+      let(:resource) { FakeResource.new(project, id: 0) }
+
+      it 'raises an error' do
+        expect { resource.destroy! }.to raise_error(Faraday::Error)
+      end
+    end
+  end
+
+  describe '#destroy' do
+    before do
+      stubs.delete("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
+        [
+          200,
+          { 'Content-Type': 'application/json' },
+          { result: nil }
+        ]
+      end
+      stubs.delete("#{Enginn::Client::BASE_URL}/projects/1/fakes/0") do |_|
+        [
+          503,
+          { 'Content-Type': 'application/json' },
+          { errors: { id: 'seriously, zero?' } }
+        ]
+      end
+    end
+
+    context 'when the request has succeeded' do
+      let(:resource) { FakeResource.new(project, id: 42) }
+
+      it 'returns true' do
+        expect(resource.destroy).to be true
+      end
+    end
+
+    context 'when the request has failed' do
+      let(:resource) { FakeResource.new(project, id: 0) }
+
+      it 'does not raise errors' do
+        expect { resource.destroy }.not_to raise_error
+      end
+
+      it 'returns false' do
+        expect(resource.destroy).to be false
+      end
+
+      it 'fill in #errors' do
+        resource.destroy
+        expect(resource.errors).not_to be_empty
+      end
+    end
   end
 
   describe '#inspect' do

--- a/spec/enginn/resource_spec.rb
+++ b/spec/enginn/resource_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Enginn::Resource do
     context 'when the request has failed' do
       it 'raises an error' do
         resource.id = 0
-        expect { resource.fetch! }.to raise_error(Faraday::Error)
+        expect { resource.fetch! }.to raise_error(Enginn::HTTPError)
       end
     end
   end
@@ -187,7 +187,7 @@ RSpec.describe Enginn::Resource do
       let(:resource) { FakeResource.new(project, { id: 0 }) }
 
       it 'raises an error' do
-        expect { resource.save! }.to raise_error(Faraday::Error)
+        expect { resource.save! }.to raise_error(Enginn::HTTPError)
       end
     end
   end
@@ -292,7 +292,7 @@ RSpec.describe Enginn::Resource do
       let(:resource) { FakeResource.new(project, id: 0) }
 
       it 'raises an error' do
-        expect { resource.destroy! }.to raise_error(Faraday::Error)
+        expect { resource.destroy! }.to raise_error(Enginn::HTTPError)
       end
     end
   end

--- a/spec/enginn/resource_spec.rb
+++ b/spec/enginn/resource_spec.rb
@@ -8,7 +8,7 @@ end
 
 RSpec.describe Enginn::Resource do
   let(:client) { Enginn::Client.new(api_token: '12345') }
-  let(:project) { Enginn::Project.new(client, { uid: 1 }) }
+  let(:project) { Enginn::Project.new(client, id: 1) }
 
   before do
     client.connection do |conn|
@@ -17,7 +17,7 @@ RSpec.describe Enginn::Resource do
           [
             200,
             { 'Content-Type': 'application/json' },
-            { result: { uid: 1, name: 'Fake Project' } }
+            { result: { id: 1, name: 'Fake Project' } }
           ]
         end
         stub.get("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|

--- a/spec/enginn/resource_spec.rb
+++ b/spec/enginn/resource_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Enginn::Resource do
   end
 
   describe '#fetch!' do
-    let(:resource) { FakeResource.new(client, project, { id: 42 }) }
+    let(:resource) { FakeResource.new(project, { id: 42 }) }
 
     before { resource.fetch! }
 
@@ -74,7 +74,7 @@ RSpec.describe Enginn::Resource do
 
   describe '#save!' do
     context 'when the resource has no ID' do
-      let(:resource) { FakeResource.new(client, project, { name: 'Fake' }) }
+      let(:resource) { FakeResource.new(project, { name: 'Fake' }) }
 
       before { resource.save! }
 
@@ -84,7 +84,7 @@ RSpec.describe Enginn::Resource do
     end
 
     context 'when the resource has an ID' do
-      let(:resource) { FakeResource.new(client, project, { id: 42, name: 'Fake' }) }
+      let(:resource) { FakeResource.new(project, { id: 42, name: 'Fake' }) }
 
       before do
         resource.name = 'New Name'
@@ -107,7 +107,7 @@ RSpec.describe Enginn::Resource do
 
   describe '#inspect' do
     it 'returns a string' do
-      expect(FakeResource.new(client, project).inspect).to be_a(String)
+      expect(FakeResource.new(project).inspect).to be_a(String)
     end
   end
 end

--- a/spec/enginn/resource_spec.rb
+++ b/spec/enginn/resource_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+class FakeResource < Enginn::Resource
+  def self.path
+    'fakes'
+  end
+end
+
+RSpec.describe Enginn::Resource do
+  let(:client) { Enginn::Client.new(api_token: '12345') }
+  let(:project) { Enginn::Project.new(client, { uid: 1 }) }
+
+  before do
+    client.connection do |conn|
+      conn.adapter :test do |stub|
+        stub.get("#{Enginn::Client::BASE_URL}/projects/1") do |_|
+          [
+            200,
+            { 'Content-Type': 'application/json' },
+            { result: { uid: 1, name: 'Fake Project' } }
+          ]
+        end
+        stub.get("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
+          [
+            200,
+            { 'Content-Type': 'application/json' },
+            { result: { id: 42, name: 'Fake' } }
+          ]
+        end
+        stub.post("#{Enginn::Client::BASE_URL}/projects/1/fakes/") do |env|
+          [
+            201,
+            { 'Content-Type': 'application/json' },
+            { result: JSON.parse(env.body).merge(id: 42) }
+          ]
+        end
+        stub.patch("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |env|
+          [
+            200,
+            { 'Content-Type': 'application/json' },
+            { result: JSON.parse(env.body).merge(id: 42) }
+          ]
+        end
+        stub.delete("#{Enginn::Client::BASE_URL}/projects/1/fakes/42") do |_|
+          [
+            200,
+            { 'Content-Type': 'application/json' },
+            { result: nil }
+          ]
+        end
+      end
+    end
+  end
+
+  after do
+    Faraday.default_connection = nil
+  end
+
+  describe '#fetch!' do
+    let(:resource) { FakeResource.new(client, project, { id: 42 }) }
+
+    before { resource.fetch! }
+
+    it 'synchronizes attributes' do
+      expect(resource.attributes).to include({ id: 42, name: 'Fake' })
+    end
+
+    it 'exposes attributes as instance methods' do
+      resource.attributes.each_key do |attr|
+        expect { resource.send(attr) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#save!' do
+    context 'when the resource has no ID' do
+      let(:resource) { FakeResource.new(client, project, { name: 'Fake' }) }
+
+      before { resource.save! }
+
+      it 'creates a new resource' do
+        expect(resource.id).to eq(42)
+      end
+    end
+
+    context 'when the resource has an ID' do
+      let(:resource) { FakeResource.new(client, project, { id: 42, name: 'Fake' }) }
+
+      before do
+        resource.name = 'New Name'
+        resource.save!
+      end
+
+      it 'updates the resource' do
+        expect(resource.name).to eq('New Name')
+      end
+    end
+  end
+
+  describe '#destroy!' do
+    pending 'How do we test/show resource destruction?'
+
+    # it 'deletes the resource' do
+    #   raise StandardError
+    # end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
+Bundler.require(:default, :test)
 
 require 'enginn'
 


### PR DESCRIPTION
Implémentation du CRUD sur les ressource `Project` et `Characters` (et `Takes`) à partir des ressources génériques `Resource` et `ResourceIndex`. Un exemple d'utilisation est présent dans le README.

## À noter

- utilisation de Faraday ce qui permet aux clients d'utiliser leur module HTTP favori. Fourni également un adaptateur pour mock
- toute action de CRUD est possible sur toutes les ressources : la réponse de l'API fait foi en cas d'opération non permise (comme la création d'un `Project` par exemple). Dans ce cas une exception est levée (à débattre de la possibilité d'avoir, comme avec ActiveRecord, des méthodes qui renvoient plutôt un booléen).
- les attributs d'une resource récupérés via `Resource#fetch!` sont également accessibles via des getters et setters définis à l'exécution
- tests unitaires du client et des classes génériques parentes
- documentation au format Yard (génération avec avec `yardoc`) => permet également l'intégration avec des outils d'autocomplétion comme Solargraph.

## À préciser et corriger

- plus de tests pour les ressources indépendantes
- voir commentaires ci-dessous dans la PR